### PR TITLE
Test sonja strieder - Tooltip for follow-nature module

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,118 +13,13 @@
 		<link href="http://www.nature.com/view/styles/global.page.css" type="text/css" rel="stylesheet" />
 		<link href="http://www.nature.com/view/styles/global.sidebar.css" type="text/css" rel="stylesheet" />
 
+		<link href="tooltip.css" type="text/css" rel="stylesheet" />
+
 		<!--[if gte IE 8]><!-->
 		<link href="http://www.nature.com/view/styles/global.mobile.css" type="text/css" rel="stylesheet" />
 		<!--<![endif]-->
 
 		<link href="http://www.nature.com/view/srep/styles/site.css" type="text/css" rel="stylesheet" />
-
-		<style>
-
-			/* =Adjustments for follow nature module */
-
-			.follow-nature ul li a {
-				text-indent: 0;
-			}
-
-			/* =Tooltip */
-
-			.tooltip {
-			}
-
-			.tooltip-text {
-				color: #333333;
-				text-indent: -999em;
-				white-space: nowrap;
-				position: fixed;
-				z-index: 9999;
-				display: inline-block;
-				margin-left: -5px;
-				background: #ffffff;
-				opacity: 0;
-				pointer-events: none;
-			}
-
-			.tooltip-text:after {
-				content: "";
-			  position: absolute;
-			  left: -5px;
-			  top: 5px;
-				display: none;
-			  height: 0;
-			  width: 0;
-				border-bottom: 5px solid transparent;
-				border-top: 5px solid transparent;
-				border-right: 5px solid #ffffff;
-			}
-
-			.tooltip-text:before {
-				content: "";
-			  position: absolute;
-			  left: -6px;
-			  top: 4px;
-				display: none;
-			  height: 0;
-			  width: 0;
-				border-bottom: 6px solid transparent;
-				border-top: 6px solid transparent;
-				border-right: 6px solid #cccccc;
-			}
-
-			/* =Tootlip left */
-
-			.tooltip--left {
-				position: relative;
-			}
-
-			.tooltip--left .tooltip-text {
-				position: absolute;
-				left: auto;
-				right: 50%;
-				margin-left: 0;
-				margin-right: -5px;
-			}
-
-			.tooltip--left .tooltip-text:after,
-			.tooltip--left .tooltip-text:before {
-				left: auto;
-				border-right: none;
-			}
-
-			.tooltip--left .tooltip-text:after {
-			  right: -5px;
-				border-top: 5px solid transparent;
-			  border-bottom: 5px solid transparent;
-			  border-left: 5px solid #ffffff;
-			}
-
-			.tooltip--left .tooltip-text:before {
-			  right: -6px;
-				border-top: 6px solid transparent;
-			  border-bottom: 6px solid transparent;
-			  border-left: 6px solid #cccccc;
-			}
-
-			/* =Show tooltip on hover */
-
-			.tooltip:hover .tooltip-text {
-				text-indent: 0;
-				text-decoration: none;
-				margin-left: 5px;
-				margin-right: 5px;
-				padding-left: .5em;
-				padding-right: .5em;
-				border: 1px solid #cccccc;
-				opacity: 1;
-				transition: opacity .25s ease-in-out, margin-left .25s ease-in-out, margin-right .25s ease-in-out;
-			}
-
-			.tooltip:hover .tooltip-text:after,
-			.tooltip:hover .tooltip-text:before {
-				display: block;
-			}
-
-		</style>
 
 		<!--[if gte IE 8]><!-->
 		<link href="http://www.nature.com/view/srep/styles/site.mobile.css" type="text/css" rel="stylesheet" />

--- a/index.html
+++ b/index.html
@@ -19,14 +19,121 @@
 
 		<link href="http://www.nature.com/view/srep/styles/site.css" type="text/css" rel="stylesheet" />
 
+		<style>
+
+			/* =Adjustments for follow nature module */
+
+			.follow-nature ul li a {
+				text-indent: 0;
+			}
+
+			/* =Tooltip */
+
+			.tooltip {
+			}
+
+			.tooltip-text {
+				color: #333333;
+				text-indent: -999em;
+				white-space: nowrap;
+				position: fixed;
+				z-index: 9999;
+				display: inline-block;
+				margin-left: -5px;
+				background: #ffffff;
+				opacity: 0;
+				pointer-events: none;
+			}
+
+			.tooltip-text:after {
+				content: "";
+			  position: absolute;
+			  left: -5px;
+			  top: 5px;
+				display: none;
+			  height: 0;
+			  width: 0;
+				border-bottom: 5px solid transparent;
+				border-top: 5px solid transparent;
+				border-right: 5px solid #ffffff;
+			}
+
+			.tooltip-text:before {
+				content: "";
+			  position: absolute;
+			  left: -6px;
+			  top: 4px;
+				display: none;
+			  height: 0;
+			  width: 0;
+				border-bottom: 6px solid transparent;
+				border-top: 6px solid transparent;
+				border-right: 6px solid #cccccc;
+			}
+
+			/* =Tootlip left */
+
+			.tooltip--left {
+				position: relative;
+			}
+
+			.tooltip--left .tooltip-text {
+				position: absolute;
+				left: auto;
+				right: 50%;
+				margin-left: 0;
+				margin-right: -5px;
+			}
+
+			.tooltip--left .tooltip-text:after,
+			.tooltip--left .tooltip-text:before {
+				left: auto;
+				border-right: none;
+			}
+
+			.tooltip--left .tooltip-text:after {
+			  right: -5px;
+				border-top: 5px solid transparent;
+			  border-bottom: 5px solid transparent;
+			  border-left: 5px solid #ffffff;
+			}
+
+			.tooltip--left .tooltip-text:before {
+			  right: -6px;
+				border-top: 6px solid transparent;
+			  border-bottom: 6px solid transparent;
+			  border-left: 6px solid #cccccc;
+			}
+
+			/* =Show tooltip on hover */
+
+			.tooltip:hover .tooltip-text {
+				text-indent: 0;
+				text-decoration: none;
+				margin-left: 5px;
+				margin-right: 5px;
+				padding-left: .5em;
+				padding-right: .5em;
+				border: 1px solid #cccccc;
+				opacity: 1;
+				transition: opacity .25s ease-in-out, margin-left .25s ease-in-out, margin-right .25s ease-in-out;
+			}
+
+			.tooltip:hover .tooltip-text:after,
+			.tooltip:hover .tooltip-text:before {
+				display: block;
+			}
+
+		</style>
+
 		<!--[if gte IE 8]><!-->
 		<link href="http://www.nature.com/view/srep/styles/site.mobile.css" type="text/css" rel="stylesheet" />
 		<!--<![endif]-->
-					
+
 		<!--[if IE 6]>
 		<script type="text/javascript" src="http://www.nature.com/view/scripts/global.ie6.js"></script>
 		<![endif]-->
-	</head>	
+	</head>
 	<!--[if lt IE 6]><body class="www-nature-com home lt-ie6"><![endif]-->
 	<!--[if IE 6]><body class="www-nature-com home ie6"><![endif]-->
 	<!--[if IE 7]><body class="www-nature-com home ie7"><![endif]-->
@@ -35,29 +142,29 @@
 	<!--[if !IE]>--><body class="www-nature-com home"><!--<![endif]-->
 
 		<div id="constrain">
-
-	
 			<div id="constrain-content" class="cleared">
-				
-				
+
 				<div id="extranav" role="complementary" class="col home">
-												
+
 					<div class="social-media module">
 						<h1>Follow us</h1>
 						<div class="follow-nature">
 							<ul>
-								<li class="rss"><a href="http://www.nature.com/srep/newsfeeds.html" title="RSS feed">RSS feed</a></li>
-								<li class="twitter"><a href="http://twitter.com/SciReports" title="Follow us on Twitter">Follow us on Twitter</a></li>
-								<li class="facebook"><a href="http://www.facebook.com/scientificreports" title="Follow us on Facebook">Follow us on Facebook</a></li>
-								<li class="friendfeed"><a href="http://friendfeed.com/scireports" title="FriendFeed">FriendFeed</a></li>
-								<li class="email"><a href="http://www.nature.com/srep/alerts/index.html" title="E-alert sign up">E-alert sign up</a></li>
+								<li class="rss"><a class="tooltip" href="http://www.nature.com/srep/newsfeeds.html"><span class="tooltip-text">RSS feed</span></a></li>
+								<li class="twitter"><a class="tooltip" href="http://twitter.com/SciReports"><span class="tooltip-text">Follow us on Twitter</span></a></li>
+								<li class="facebook"><a class="tooltip" href="http://www.facebook.com/scientificreports"><span class="tooltip-text">Follow us on Facebook</span></a></li>
+								<li class="friendfeed"><a class="tooltip" href="http://friendfeed.com/scireports"><span class="tooltip-text">FriendFeed</span></a></li>
+								<li class="email"><a class="tooltip tooltip--left" href="http://www.nature.com/srep/alerts/index.html"><span class="tooltip-text">E-alert sign up</span></a></li>
 							</ul>
 						</div>
 					</div>
-				</div>	
-			</div>	
+				</div>
+
+			</div>
 		</div>
+
 		<script src="http://www.nature.com/view/scripts/jquery/jquery-1.7.js" type="text/javascript"></script>
 		<script src="http://www.nature.com/view/srep/scripts/site.js" type="text/javascript"></script>
+
 	</body>
 </html>

--- a/tooltip.css
+++ b/tooltip.css
@@ -1,0 +1,100 @@
+/* =Adjustments for follow nature module */
+/* TODO: Update in site.css*/
+
+.follow-nature ul li a {
+  text-indent: 0;
+}
+
+/* =Tooltip */
+
+.tooltip-text {
+  color: #333333;
+  text-indent: -999em;
+  white-space: nowrap;
+  position: fixed;
+  z-index: 9999;
+  display: inline-block;
+  margin-left: -5px;
+  background: #ffffff;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.tooltip-text:after {
+  content: "";
+  position: absolute;
+  left: -5px;
+  top: 5px;
+  display: none;
+  height: 0;
+  width: 0;
+  border-bottom: 5px solid transparent;
+  border-top: 5px solid transparent;
+  border-right: 5px solid #ffffff;
+}
+
+.tooltip-text:before {
+  content: "";
+  position: absolute;
+  left: -6px;
+  top: 4px;
+  display: none;
+  height: 0;
+  width: 0;
+  border-bottom: 6px solid transparent;
+  border-top: 6px solid transparent;
+  border-right: 6px solid #cccccc;
+}
+
+/* =Tootlip left */
+
+.tooltip--left {
+  position: relative;
+}
+
+.tooltip--left .tooltip-text {
+  position: absolute;
+  left: auto;
+  right: 50%;
+  margin-left: 0;
+  margin-right: -5px;
+}
+
+.tooltip--left .tooltip-text:after,
+.tooltip--left .tooltip-text:before {
+  left: auto;
+  border-right: none;
+}
+
+.tooltip--left .tooltip-text:after {
+  right: -5px;
+  border-top: 5px solid transparent;
+  border-bottom: 5px solid transparent;
+  border-left: 5px solid #ffffff;
+}
+
+.tooltip--left .tooltip-text:before {
+  right: -6px;
+  border-top: 6px solid transparent;
+  border-bottom: 6px solid transparent;
+  border-left: 6px solid #cccccc;
+}
+
+/* =Show tooltip on hover */
+
+.tooltip:hover .tooltip-text {
+  text-indent: 0;
+  text-decoration: none;
+  margin-left: 5px;
+  margin-right: 5px;
+  padding-left: .5em;
+  padding-right: .5em;
+  border: 1px solid #cccccc;
+  opacity: 1;
+  transition: opacity .25s ease-in-out, margin-left .25s ease-in-out, margin-right .25s ease-in-out;
+}
+
+.tooltip:hover .tooltip-text:after,
+.tooltip:hover .tooltip-text:before {
+  display: block;
+}


### PR DESCRIPTION
I've opted for a simple css only implementation in the end based on the existing follow-nature module. Which ideally I would rewrite to make it work without overflow: hidden; as this caused issues with the tooltip, e.g. if the container is too small and the tooltip overflows the box. 

Improvements:
- Enhance the tooltip by adding some javascript code that positions the tooltip  relative to the mouse pointer also taking into account the browser window making sure it alines left/right/top/bottom depending on how close it is to the browser window. Now, I've had that working but ended up with a bug that I wasn't able to fix in time and decided to remove it.
- Mobile: I'd need to know a bit more context to make a decision on what do do for touch devices. If the text needs to show at all costs then I would show the icon with the text next to it for touch devices.
